### PR TITLE
feat: Auto-close warning popup for unknown path

### DIFF
--- a/release/scripts/newlife2.ash
+++ b/release/scripts/newlife2.ash
@@ -4,13 +4,53 @@ notify "philmasterplus";
 since r20653; // Torso Awaregness -> Torso Awareness
 import "zlib.ash";
 
-if(!($strings[None, Standard, Teetotaler, Boozetafarian, Oxygenarian, Bees Hate You, Way of the Surprising Fist, Trendy,
-Avatar of Boris, Bugbear Invasion, Zombie Slayer, Class Act, Avatar of Jarlsberg, BIG!, KOLHS, Class Act II: A Class For Pigs,
-Avatar of Sneaky Pete, Slow and Steady, Heavy Rains, Picky, Actually Ed the Undying, One Crazy Random Summer, Community Service,
-Avatar of West of Loathing, The Source, Nuclear Autumn, Gelatinous Noob, License to Adventure]
-  contains my_path()) && user_confirm("Your current challenge path is unknown to newLife!\nUnknown and unknowable errors may take place if it is run.\nDo you want to abort?")) {
-	vprint("Your current path is unknown to newLife! A new version of this script should be released very soon.", -1);
-	exit;
+if (
+	!(
+		$strings[
+			None,
+			Standard,
+			Teetotaler,
+			Boozetafarian,
+			Oxygenarian,
+			Bees Hate You,
+			Way of the Surprising Fist,
+			Trendy,
+			Avatar of Boris,
+			Bugbear Invasion,
+			Zombie Slayer,
+			Class Act,
+			Avatar of Jarlsberg,
+			BIG!,
+			KOLHS,
+			Class Act II: A Class For Pigs,
+			Avatar of Sneaky Pete,
+			Slow and Steady,
+			Heavy Rains,
+			Picky,
+			Actually Ed the Undying,
+			One Crazy Random Summer,
+			Community Service,
+			Avatar of West of Loathing,
+			The Source,
+			Nuclear Autumn,
+			Gelatinous Noob,
+			License to Adventure,
+		] contains my_path()
+	)
+) {
+	int countdown = 30;
+	string warning_message =
+		`newLife2 does not officially support your current path ("{my_path()}").` +
+		`\nIf you continue, it may select suboptimal choices and do strange things.` +
+		`\nDo you want to abort?` +
+		`\n(newLife2 will continue in {countdown} seconds.)`;
+	if (user_confirm(warning_message, countdown * 1000, false)) {
+		vprint(
+			`Aborting because newLife2 does not know how to handle your current path ("{my_path()}").`,
+			-1
+		);
+		exit;
+	}
 }
 
 // Often I get this script out before full mafia support. Hence these variable are used.


### PR DESCRIPTION
If the current path is unknown (i.e. not officially supported by newLife2), the popup closes after 30 seconds and allows the script to
continue. This should help automation scripts deal with newer paths (e.g. You, Robot) while giving users enough time to manually abort.

Also reformat/refactor the code so that maintenance is easier.

- Related forum post(s):
  - https://kolmafia.us/threads/scripting-the-birth-of-a-new-life.2769/post-161584
  - https://kolmafia.us/threads/scripting-the-birth-of-a-new-life.2769/post-161586 